### PR TITLE
Remove unneded future_join gate, fix compilation when git is missing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(future_join)]
 
 mod commands;
 mod indications;
@@ -64,7 +63,7 @@ async fn main(spawner: Spawner) {
 
     info!(
         "ti-i2c ({}) is running. Hello!",
-        git_version!(args = ["--tags", "--dirty"])
+        git_version!(args = ["--tags", "--dirty"], fallback = "unknown")
     );
 
     static LED_INDICATIONS: LedIndications = LedIndications::new();


### PR DESCRIPTION
Fixes #2 

`#![feature(future_join)]` is a nightly feature which is not used at the moment, so no need to keep it.
Fallback to "unknown" version if full git repo is not available or git itself is missing